### PR TITLE
add option to async_worker_group for ipv4 only

### DIFF
--- a/async_worker_group_example_test.go
+++ b/async_worker_group_example_test.go
@@ -52,6 +52,7 @@ func ExampleAsyncWorkerGroup() {
 	// Initialize a worker group.
 	g, err := NewAsyncWorkerGroup(
 		jwtConfig,
+		false,
 		SetAsyncNumWorkers(10),               // Number of background workers in the group.
 		SetAsyncMaxRows(500),                 // Amount of rows that must be enqueued before executing an insert operation to BigQuery.
 		SetAsyncMaxDelay(1*time.Second),      // Time to wait between inserts.

--- a/async_worker_group_test.go
+++ b/async_worker_group_test.go
@@ -24,7 +24,7 @@ func TestAsyncWorkerGroupNew(t *testing.T) {
 
 	// TestAsyncWorkerGroup giving bad arguments.
 	var err error
-	_, err = NewAsyncWorkerGroup(nil)
+	_, err = NewAsyncWorkerGroup(nil, false)
 	assert.EqualError(err, "jwt.Config is nil")
 	errChan := make(chan *InsertErrors)
 	_, err = newAsyncWorkerGroup(


### PR DESCRIPTION
this is to fix an upstream situation where v6 routes exist but there is no connectvity to googleapis.