### PR TITLE
Extra option: accepting a circuit breaker injection

### DIFF
--- a/async_worker_group.go
+++ b/async_worker_group.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cep21/circuit/v3"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jwt"
@@ -50,6 +51,10 @@ type AsyncWorkerGroup struct {
 	// The default value is false, which causes the entire request
 	// to fail if any invalid rows exist.
 	skipInvalidRows bool
+
+	// Optional circuit breaker injection. If provided, all workers will
+	// wrap insert operations with it
+	circuit *circuit.Circuit
 }
 
 var dialer = &net.Dialer{}
@@ -116,6 +121,7 @@ func newAsyncWorkerGroup(newHTTPClient func() *http.Client, options ...AsyncOpti
 			SetSyncRetryInterval(m.retryInterval),
 			SetSyncIgnoreUnknownValues(m.ignoreUnknownValues),
 			SetSyncSkipInvalidRows(m.skipInvalidRows),
+			SetSyncCircuitBreaker(m.circuit),
 		)
 		if err != nil {
 			return nil, err

--- a/async_worker_group_options.go
+++ b/async_worker_group_options.go
@@ -5,6 +5,8 @@ package bqstreamer
 import (
 	"errors"
 	"time"
+
+	"github.com/cep21/circuit/v3"
 )
 
 const (
@@ -124,6 +126,16 @@ func SetAsyncIgnoreUnknownValues(ignore bool) AsyncOptionFunc {
 func SetAsyncSkipInvalidRows(skip bool) AsyncOptionFunc {
 	return func(w *AsyncWorkerGroup) error {
 		w.skipInvalidRows = skip
+		return nil
+	}
+}
+
+
+// SetAsyncCircuitBreaker allows you to set a cep21/circuit, which will wrap all
+// insert operations for all workers
+func SetAsyncCircuitBreaker(circuit *circuit.Circuit) AsyncOptionFunc {
+	return func(w *AsyncWorkerGroup) error {
+		w.circuit = circuit
 		return nil
 	}
 }

--- a/sync_options.go
+++ b/sync_options.go
@@ -5,6 +5,8 @@ package bqstreamer
 import (
 	"errors"
 	"time"
+
+	"github.com/cep21/circuit/v3"
 )
 
 const (
@@ -63,6 +65,15 @@ func SetSyncIgnoreUnknownValues(ignore bool) SyncOptionFunc {
 func SetSyncSkipInvalidRows(skip bool) SyncOptionFunc {
 	return func(w *SyncWorker) error {
 		w.skipInvalidRows = skip
+		return nil
+	}
+}
+
+// SetSyncCircuitBreaker allows you to set a cep21/circuit, which will wrap all
+// insert operations
+func SetSyncCircuitBreaker(circuit *circuit.Circuit) SyncOptionFunc {
+	return func(w *SyncWorker) error {
+		w.circuit = circuit
 		return nil
 	}
 }


### PR DESCRIPTION
Adding some extra async/sync options to accept a circuit breaker to wrap bq insert calls. Not abstracting the circuit breaker, or providing defaults, but letting the caller to inject a specific and already configured instance, making things more flexible. If no circuit is set, we will be calling the insert operation as we already did